### PR TITLE
Add fastlane run_tests_firebase_testlab plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN tar -xvzf ./inst.tgz
 RUN mv ./lokalise /usr/local/bin/lokalise
 
 RUN gem install fastlane dotenv json
+RUN fastlane add_plugin run_tests_firebase_testlab
 
 RUN npm install -g webpack webpack-cli wrapper-webpack-plugin
 


### PR DESCRIPTION
Needed for enabling instrumental test using Firebase test lab farm.